### PR TITLE
Change path param to fsPath

### DIFF
--- a/src/modules/stateful-to-stateless.ts
+++ b/src/modules/stateful-to-stateless.ts
@@ -436,7 +436,7 @@ export async function statefulToStatelessComponent() {
   }
 
   function importHooks(...hooks) {
-    const currentFile = activeURI().path;
+    const currentFile = activeURI().fsPath;
     const file = readFileContent(currentFile);
     const ast = codeToAst(file);
     const reactImport = getReactImportReference(ast);


### PR DESCRIPTION
Change path param to fsPath for activeURI function

For this error:
ENOENT: no such file or directory, open /d:/project/...