### PR TITLE
fix(experiments): update experiments settings schema in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,11 @@
         },
         "glean.experiments": {
           "type": [
-            "string"
+            "array"
           ],
+          "items": {
+              "type": "string"
+          },
           "default": [],
           "description": "Active experimental features. Please see https://github.com/wix/vscode-glean/ for list of experimental features"
         }


### PR DESCRIPTION
The settings schema expects `glean.experiments` to be string, however, the current value for experiments is an array of strings.
The purpose of this small PR is to fix the settings schema.

It fixes one of the problems mentioned in #75 