### PR TITLE
Adds state class property support to the stateful-to-stateless transform

### DIFF
--- a/src/modules/stateful-to-stateless.ts
+++ b/src/modules/stateful-to-stateless.ts
@@ -278,6 +278,12 @@ export function statefulToStateless(component) {
       ) {
         copyNonLifeCycleMethods(path);
       }
+      if (t.isObjectExpression(propValue) && path.node.key.name === "state") {
+        stateHooksPresent = true;
+        propValue.properties.map(({ key, value }) => {
+          stateProperties.set(key.name, value);
+        });
+      }
     },
 
     ImportDeclaration(path) {

--- a/src/modules/stateful-to-stateless.ts
+++ b/src/modules/stateful-to-stateless.ts
@@ -280,7 +280,7 @@ export function statefulToStateless(component) {
       }
       if (t.isObjectExpression(propValue) && path.node.key.name === "state") {
         stateHooksPresent = true;
-        propValue.properties.map(({ key, value }) => {
+        (propValue.properties as t.ObjectProperty[]).map(({ key, value }) => {
           stateProperties.set(key.name, value);
         });
       }


### PR DESCRIPTION
I've noticed that when the state is initialized as a class property (rather than in the constructor), it's ignored by stateful-to-stateless. For example:

```js
class Foo extends React.Component {
  state = {
    vixe: 1,
    oxe: "bla"
  };

  render() {

  }
}
```
becomes

```js
const Foo = props => {};
```
instead of 

```js
const Foo = props => {
  const [vixe, setVixe] = useState(1);
  const [oxe, setOxe] = useState("bla");
};
```

This PR adds a simple fix