### PR TITLE
Change incorrect type for jsFilesExtensions setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
           "description": "Module system to be used whem extracting Javascript"
         },
         "glean.jsFilesExtensions": {
-          "type": [
-            "string"
-          ],
+          "type": "array",
           "default": [
             "js",
             "jsx",


### PR DESCRIPTION
<img width="472" alt="image" src="https://user-images.githubusercontent.com/1380307/84278573-393ae980-ab35-11ea-8c88-324db3ee7866.png">

The [documentation of type definitions in VSCode extensions](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration) is not very clear, but it seems like an array of types means "any of these types" rather than "an array with elements of this type". VSCode at least complains to setting this setting to its default value or to an array.

The same kind of definition is also used for the `experiments` setting, but i guess it works out anyway there since the only allowed type is an array.