### PR TITLE
Fix React Version check in settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { config } from './editor';
 
-const ReactVersion = require('child_process').execSync('npm list react --version --depth=0').toString().trim().split('.').map(Number);
+const ReactVersion = require('child_process').execSync('npm view react version').toString().trim().split('.').map(Number);
 
 export const shouldBeConsideredJsFiles = (...files) => {
     const extentionsToBeConsideredJS = config().jsFilesExtensions;


### PR DESCRIPTION
`npm list react --version --depth=0` appears to return the version of the npm cli not the version of React. Maybe something changed in the npm API? I'm using npm:v6.14.4/node:v12.16.2 and all of these commands return the same value (the version of npm I'm using):

```bash
npm --version # output: 6.14.4
npm list --version  # output: 6.14.4
npm list react --version  # output: 6.14.4
npm list react --version --depth=0  # output: 6.14.4
```

This command seems to be a good alternative `npm view react version`. I tested it as far back as npm:v5.3.0/node:v8.4.0.
