### PR TITLE
Update target to ES2020 instead of ES6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2020",
         "outDir": "out",
         "lib": [
             "es2017",


### PR DESCRIPTION
ES6 is almost 7 years old. We can target ES2020 without problems for VSCode.

[Related issue](https://github.com/microsoft/vscode-extension-samples/issues/530).